### PR TITLE
docs: fix citation section and stable docs badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spectra.jl
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg?label=docs)](https://juliaastro.org/Spectra/stable)
+[![](https://img.shields.io/badge/docs-stable-blue.svg?label=docs)](https://juliaastro.org/Spectra.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg?label=docs)](https://juliaastro.org/Spectra.jl/dev)
 
 [![CI](https://github.com/JuliaAstro/Spectra.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaAstro/Spectra.jl/actions/workflows/CI.yml)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,13 +59,8 @@ For constructing higher dimensional spectra, e.g., for echelle or IFU spectra, s
 
 If you found this software or any derivative work useful in your academic work, I ask that you please cite the code.
 
-The preferred citation metadata is available in [CITATION.cff](https://github.com/JuliaAstro/Spectra.jl/blob/main/CITATION.cff).
-
-```yaml
-cff-version: 1.2.0
-type: software
-title: Spectra.jl
-repository-code: https://github.com/JuliaAstro/Spectra.jl
+```
+TODO
 ```
 
 ## Contributing

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,8 +59,13 @@ For constructing higher dimensional spectra, e.g., for echelle or IFU spectra, s
 
 If you found this software or any derivative work useful in your academic work, I ask that you please cite the code.
 
-```
-TODO
+The preferred citation metadata is available in [CITATION.cff](https://github.com/JuliaAstro/Spectra.jl/blob/main/CITATION.cff).
+
+```yaml
+cff-version: 1.2.0
+type: software
+title: Spectra.jl
+repository-code: https://github.com/JuliaAstro/Spectra.jl
 ```
 
 ## Contributing


### PR DESCRIPTION
### PR Summary

- Replaces placeholder Citation section content in [docs/src/index.md](docs/src/index.md) with CFF-based citation information.
- Fixes the stable docs badge URL in [README.md](README.md) to use the Spectra.jl docs path.
- No code-path changes; this is a docs-only cleanup.

### Why

- Makes citation guidance immediately usable for users and contributors.
- Ensures README badges point to the correct stable documentation location.
- Keeps scope minimal and low risk by changing documentation only.